### PR TITLE
More enhancements: root .env, colorlog + DEBUG logging, tabbed playlist browser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Copy to backend/.env and fill in. Loaded by backend/common/config.py.
+# Copy to ./.env (project root) and fill in. Loaded by backend/common/config.py.
 #
 # Convention: this file holds ONLY secrets (credentials) — it's gitignored, never commit
 # real values. Non-secret config (REDIRECT_URI, RECOMMENDER, GEMINI_MODEL, LOG_LEVEL) lives

--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ is same-origin, so there's no CORS and the OAuth redirect targets one URL.
 
 ## Configuration
 
-Config is split by sensitivity: **secrets live in `backend/.env`** (gitignored, secrets-only),
-**non-secret config lives in `docker-compose*.yml`** (committed, reviewable). Compose pulls the
-secrets via `env_file` and sets the non-secrets inline; `backend/common/config.py` holds sane
-defaults as a fallback. Copy `backend/.env.example` to `backend/.env` to start.
+Config is split by sensitivity: **secrets live in `./.env`** at the project root (gitignored,
+secrets-only), **non-secret config lives in `docker-compose*.yml`** (committed, reviewable).
+Compose pulls the secrets via `env_file` and sets the non-secrets inline; `backend/common/config.py`
+holds sane defaults as a fallback. Copy `.env.example` to `./.env` to start. (A legacy
+`backend/.env` is still read if present, but the root `.env` is the canonical location.)
 
-**Secrets — in `backend/.env`:**
+**Secrets — in `./.env`:**
 
 | Variable | Required | Notes |
 |----------|----------|-------|

--- a/backend/common/config.py
+++ b/backend/common/config.py
@@ -29,9 +29,11 @@ ENGINE_LABELS = {
 
 
 class Settings(BaseSettings):
-    # Environment variables take precedence; either .env location is read if present.
+    # Environment variables take precedence. The project-root `.env` is the canonical
+    # location; `backend/.env` is still read as a legacy fallback. Later entries win, so
+    # root overrides backend if both somehow exist.
     model_config = SettingsConfigDict(
-        env_file=(_ROOT / ".env", _PKG / ".env"),
+        env_file=(_PKG / ".env", _ROOT / ".env"),
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",

--- a/backend/common/constants.py
+++ b/backend/common/constants.py
@@ -10,3 +10,8 @@ SPOTIFY_SCOPE = (
 
 # Placeholder cover used when a playlist has no artwork.
 DEFAULT_IMAGE_URL = "https://i.imgur.com/lBzb2v2.png"
+
+# Stamped into the description of playlists this app creates (daily/weekly/created-from)
+# so the UI can tell them apart from the user's own playlists. Spotify exposes no custom
+# metadata, but `description` is writable and returned when listing — so it's our marker.
+APP_PLAYLIST_MARKER = "Made with SpotifyProject"

--- a/backend/common/logging_config.py
+++ b/backend/common/logging_config.py
@@ -1,54 +1,103 @@
+"""Logging configuration — colored console (colorlog) + daily rotating file.
+
+Matches the palworld-lens convention: a single `setup_logging()` that configures the
+root logger with colored levels for the console, plus `get_logger()` for named loggers.
+The module-level `logger` is kept and configured on import, so existing
+`from backend.common.logging_config import logger` call sites keep working unchanged.
+"""
+
+import datetime
 import logging
 import os
 from logging.handlers import TimedRotatingFileHandler
-import datetime
 
-class CustomTimedRotatingFileHandler(TimedRotatingFileHandler):
+import colorlog
+
+# logs live next to this module: backend/common/logs/
+_LOG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+
+# Console keeps the colored level; file stays plain text. Both retain %(filename)s so
+# the originating source file is visible (all modules share the root logger, so a logger
+# name would be constant and useless — the filename is what tells them apart).
+_CONSOLE_FORMAT = "%(log_color)s%(levelname)-8s%(reset)s %(asctime)s %(filename)s: %(message)s"
+_FILE_FORMAT = "%(asctime)s [%(levelname)s] %(filename)s: %(message)s"
+_DATEFMT = "%Y-%m-%d %H:%M:%S"
+_LOG_COLORS = {
+    "DEBUG": "cyan",
+    "INFO": "green",
+    "WARNING": "yellow",
+    "ERROR": "red",
+    "CRITICAL": "red,bg_white",
+}
+# Chatty third-party loggers pinned to WARNING so our own logs stay readable.
+_NOISY = ("httpx", "httpcore", "google_genai", "google.genai", "urllib3", "spotipy")
+
+
+class _DailyRotatingFileHandler(TimedRotatingFileHandler):
+    """Roll at midnight, naming each file logfile_YYYY-MM-DD.log."""
+
     def doRollover(self):
-        self.baseFilename = os.path.join(log_dir, f"logfile_{datetime.datetime.now().strftime('%Y-%m-%d')}.log")
-        TimedRotatingFileHandler.doRollover(self)
+        self.baseFilename = os.path.join(
+            _LOG_DIR, f"logfile_{datetime.datetime.now():%Y-%m-%d}.log"
+        )
+        super().doRollover()
 
-log_level = os.getenv('LOG_LEVEL', 'INFO').upper()
-numeric_level = getattr(logging, log_level, None)
 
-if not isinstance(numeric_level, int):
-    raise ValueError(f'Invalid log level: {log_level}')
+def _coerce_level(level: str | int | None) -> int:
+    if level is None:
+        level = os.getenv("LOG_LEVEL", "INFO").upper()
+    if isinstance(level, int):
+        return level
+    numeric = getattr(logging, level, None)
+    if not isinstance(numeric, int):
+        raise ValueError(f"Invalid log level: {level}")
+    return numeric
 
-log_format = '%(asctime)s [%(levelname)s] %(filename)s: %(message)s'
 
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
+def setup_logging(level: str | int | None = None) -> logging.Logger:
+    """Configure the root logger: colored console + daily rotating file. Idempotent —
+    existing handlers are cleared first, so it is safe to call more than once."""
+    numeric_level = _coerce_level(level)
 
-# Join it with 'logs' to get the path to the logs directory
-log_dir = os.path.join(script_dir, 'logs')
+    root = logging.getLogger()
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
 
-if not os.path.exists(log_dir):
-    os.makedirs(log_dir)
+    console = colorlog.StreamHandler()
+    console.setFormatter(
+        colorlog.ColoredFormatter(
+            _CONSOLE_FORMAT, datefmt=_DATEFMT, reset=True, log_colors=_LOG_COLORS
+        )
+    )
 
-# Create a timed rotating file handler that creates a new file every day and keeps logs for a week
-# The log files are named with the current date
-file_handler = CustomTimedRotatingFileHandler(os.path.join(log_dir, f"logfile_{datetime.datetime.now().strftime('%Y-%m-%d')}.log"), when='midnight', interval=1, backupCount=7)
-file_handler.setLevel(numeric_level)
+    os.makedirs(_LOG_DIR, exist_ok=True)
+    file_handler = _DailyRotatingFileHandler(
+        os.path.join(_LOG_DIR, f"logfile_{datetime.datetime.now():%Y-%m-%d}.log"),
+        when="midnight",
+        interval=1,
+        backupCount=7,
+    )
+    file_handler.setFormatter(logging.Formatter(_FILE_FORMAT, datefmt=_DATEFMT))
 
-# Create a console handler
-console_handler = logging.StreamHandler()
-console_handler.setLevel(numeric_level)
+    for handler in (console, file_handler):
+        handler.setLevel(numeric_level)
+        root.addHandler(handler)
+    root.setLevel(numeric_level)
 
-# Create a formatter and set it for both handlers
-formatter = logging.Formatter(log_format, datefmt='%Y-%m-%d %H:%M:%S')
-file_handler.setFormatter(formatter)
-console_handler.setFormatter(formatter)
+    for noisy in _NOISY:
+        logging.getLogger(noisy).setLevel(logging.WARNING)
 
-# Get the root logger and set its level
+    root.info("Logging configured at %s", logging.getLevelName(numeric_level))
+    return root
+
+
+def get_logger(name: str) -> logging.Logger:
+    """A named logger (palworld-lens parity). All loggers propagate to the root handlers
+    configured by setup_logging()."""
+    return logging.getLogger(name)
+
+
+# Configure on import and export a default logger so existing
+# `from backend.common.logging_config import logger` imports keep working.
+setup_logging()
 logger = logging.getLogger()
-logger.setLevel(numeric_level)
-
-print(f"Log level set to: {logging.getLevelName(logger.level)}")
-
-# Quiet chatty third-party libraries so our own logs stay readable.
-for _noisy in ("httpx", "httpcore", "google_genai", "google.genai", "urllib3", "spotipy"):
-    logging.getLogger(_noisy).setLevel(logging.WARNING)
-
-# Add both handlers to the root logger
-logger.addHandler(file_handler)
-logger.addHandler(console_handler)

--- a/backend/core/playlists.py
+++ b/backend/core/playlists.py
@@ -37,9 +37,15 @@ def _recommend_uris(
     """seeds → recommender → resolve → dedupe → shuffle → slice to `count`."""
     if not seeds:
         return []
+    logger.debug(
+        "Build pipeline: %d seeds, requesting %d tracks (excluding %d existing)",
+        len(seeds), count, len(exclude_uris or ()),
+    )
     suggestions = recommender.recommend(seeds, count)
+    logger.debug("Build pipeline: recommender returned %d suggestions; resolving", len(suggestions))
     uris = resolve_all(client.sp, suggestions, limit=count, exclude_uris=exclude_uris)
     random.shuffle(uris)
+    logger.debug("Build pipeline: %d playable tracks after resolve/dedupe/slice", len(uris))
     return uris
 
 

--- a/backend/core/playlists.py
+++ b/backend/core/playlists.py
@@ -8,8 +8,10 @@ Spotify. Routes stay thin by calling these; these stay testable by depending onl
 from __future__ import annotations
 
 import random
+import re
 from datetime import datetime
 
+from backend.common.constants import APP_PLAYLIST_MARKER
 from backend.common.logging_config import logger
 from .recommender.base import Recommender, Seed
 from .resolver import resolve_all
@@ -20,10 +22,23 @@ DEFAULT_DAILY_COUNT = 40
 WEEKLY_EXTEND_COUNT = 40
 _MAX_PLAYLIST_SONGS = 200
 
+# Matches the daily naming format (e.g. "Jun-23-2026") — used to recognize dailies
+# created before the description marker existed.
+_DAILY_NAME_RE = re.compile(r"^[A-Z][a-z]{2}-\d{2}-\d{4}$")
+
 
 def daily_playlist_name(today: datetime | None = None) -> str:
     """Daily playlists are named by date, e.g. 'Jun-22-2026'."""
     return (today or datetime.today()).strftime("%b-%d-%Y")
+
+
+def is_app_created(name: str, description: str | None) -> bool:
+    """Whether a playlist was made by this app. Primary signal is the description marker
+    (reliable, set on everything we create going forward); the name heuristic backfills
+    playlists created before the marker existed (the date-named daily, the weekly)."""
+    if description and APP_PLAYLIST_MARKER in description:
+        return True
+    return name == WEEKLY_PLAYLIST_NAME or bool(_DAILY_NAME_RE.match(name))
 
 
 def _recommend_uris(
@@ -57,7 +72,7 @@ def create_daily_playlist(
     if not uris:
         raise ValueError("No playable recommendations were found. Try again later.")
     name = daily_playlist_name()
-    client.create_playlist(client.current_user_id(), name, uris)
+    client.create_playlist(client.current_user_id(), name, uris, description=APP_PLAYLIST_MARKER)
     logger.info("Daily playlist created: %s (%d tracks)", name, len(uris))
     return f"Daily playlist created with name: {name}"
 
@@ -70,7 +85,9 @@ def extend_weekly_playlist(client: SpotifyClient, recommender: Recommender) -> s
         uris = _recommend_uris(client, recommender, seeds, WEEKLY_EXTEND_COUNT)
         if not uris:
             raise ValueError("No playable recommendations were found. Try again later.")
-        client.create_playlist(client.current_user_id(), WEEKLY_PLAYLIST_NAME, uris)
+        client.create_playlist(
+            client.current_user_id(), WEEKLY_PLAYLIST_NAME, uris, description=APP_PLAYLIST_MARKER
+        )
         return f"Playlist created with name: {WEEKLY_PLAYLIST_NAME}"
 
     existing = client.playlist_track_uris(playlist_id)
@@ -115,6 +132,8 @@ def create_playlist_from_playlist(
     uris = _recommend_uris(client, recommender, seeds, count)
     if not uris:
         raise ValueError("No playable recommendations were found. Try again later.")
-    client.create_playlist(client.current_user_id(), target_name, uris)
+    client.create_playlist(
+        client.current_user_id(), target_name, uris, description=APP_PLAYLIST_MARKER
+    )
     logger.info("Playlist created: %s (%d tracks)", target_name, len(uris))
     return f"Playlist created: {target_name}"

--- a/backend/core/recommender/base.py
+++ b/backend/core/recommender/base.py
@@ -13,6 +13,15 @@ from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 
+def preview(items, limit: int = 10) -> str:
+    """Compact 'Title — Artist, ...' rendering of seeds/suggestions for DEBUG logs,
+    truncated to `limit` with a '(+N more)' tail so big lists stay one readable line.
+    Works for anything with .title/.artist (both Seed and Suggestion)."""
+    shown = ", ".join(f"{i.title} — {i.artist}" for i in items[:limit])
+    extra = len(items) - limit
+    return f"{shown} (+{extra} more)" if extra > 0 else (shown or "(none)")
+
+
 class RecommenderError(RuntimeError):
     """An engine failed hard (auth, exhausted credits, rate limit, network) after its
     own retries. Distinct from "no results" — surfaced to the user with the cause,

--- a/backend/core/recommender/catalog.py
+++ b/backend/core/recommender/catalog.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import random
 
 from backend.common.logging_config import logger
-from .base import Recommender, Seed, Suggestion
+from .base import Recommender, Seed, Suggestion, preview
 
 
 class CatalogRecommender(Recommender):
@@ -56,8 +56,11 @@ class CatalogRecommender(Recommender):
         for artist_name in {s.artist for s in seeds}:  # dedupe seed artists
             artist_id = self._artist_id(artist_name)
             if artist_id is None:
+                logger.debug("Catalog: no Spotify artist match for %r", artist_name)
                 continue
-            for suggestion in self._top_tracks(artist_id):
+            tracks = self._top_tracks(artist_id)
+            logger.debug("Catalog: %d top tracks for artist %r", len(tracks), artist_name)
+            for suggestion in tracks:
                 key = (suggestion.title.lower(), suggestion.artist.lower())
                 if key not in seen:
                     seen.add(key)
@@ -65,5 +68,6 @@ class CatalogRecommender(Recommender):
 
         random.shuffle(candidates)
         logger.info("Catalog recommender produced %d candidates.", len(candidates))
+        logger.debug("Catalog candidates (shuffled): %s", preview(candidates))
         # Over-return a little; the resolver/pipeline slices to the final count.
         return candidates[: max(count * 2, count)]

--- a/backend/core/recommender/claude.py
+++ b/backend/core/recommender/claude.py
@@ -9,10 +9,12 @@ anything is added.
 
 from __future__ import annotations
 
+import time
+
 from pydantic import BaseModel
 
 from backend.common.logging_config import logger
-from .base import Recommender, RecommenderError, Seed, Suggestion
+from .base import Recommender, RecommenderError, Seed, Suggestion, preview
 
 _OVER_REQUEST = 1.25  # ask for ~25% more than needed to absorb resolver misses
 _MAX_TOKENS = 8000    # enough for a few hundred {title, artist} pairs
@@ -59,11 +61,18 @@ class ClaudeRecommender(Recommender):
             return []
 
         ask = max(count, int(count * _OVER_REQUEST))
+        prompt = self._build_prompt(seeds, ask)
+        logger.debug(
+            "Claude: requesting %d suggestions (model=%s) from %d seeds: %s",
+            ask, self._model, len(seeds), preview(seeds),
+        )
+        logger.debug("Claude prompt:\n%s", prompt)
         try:
+            started = time.perf_counter()
             response = self._get_client().messages.parse(
                 model=self._model,
                 max_tokens=self._max_tokens,
-                messages=[{"role": "user", "content": self._build_prompt(seeds, ask)}],
+                messages=[{"role": "user", "content": prompt}],
                 output_format=_SuggestionList,
             )
         except Exception as exc:  # noqa: BLE001 — surface the cause (credits/auth/rate limit)
@@ -80,4 +89,8 @@ class ClaudeRecommender(Recommender):
             artist = (item.artist or "").strip()
             if title and artist:
                 out.append(Suggestion(title=title, artist=artist))
+        logger.debug(
+            "Claude: %d usable suggestions (of %d raw) in %.2fs: %s",
+            len(out), len(parsed.songs), time.perf_counter() - started, preview(out),
+        )
         return out

--- a/backend/core/recommender/factory.py
+++ b/backend/core/recommender/factory.py
@@ -7,7 +7,8 @@ resolved the "engine requested but no key" degrade-to-catalog decision.
 
 from __future__ import annotations
 
-from backend.common.config import Settings
+from backend.common.config import ENGINE_LABELS, Settings
+from backend.common.logging_config import logger
 from .base import Recommender
 from .catalog import CatalogRecommender
 
@@ -18,16 +19,28 @@ def build_recommender(settings: Settings, sp, engine: str | None = None) -> Reco
     # resolved — its key is guaranteed present for keyed engines.
     if engine is None:
         engine = settings.effective_recommender
+
     if engine == "lastfm":
         from .lastfm import LastfmRecommender
 
-        return LastfmRecommender(settings.lastfm_api_key)
-    if engine == "gemini":
+        recommender: Recommender = LastfmRecommender(settings.lastfm_api_key)
+    elif engine == "gemini":
         from .gemini import GeminiRecommender
 
-        return GeminiRecommender(settings.gemini_api_key, settings.gemini_model)
-    if engine == "claude":
+        recommender = GeminiRecommender(settings.gemini_api_key, settings.gemini_model)
+    elif engine == "claude":
         from .claude import ClaudeRecommender
 
-        return ClaudeRecommender(settings.anthropic_api_key, settings.claude_model)
-    return CatalogRecommender(sp)
+        recommender = ClaudeRecommender(settings.anthropic_api_key, settings.claude_model)
+    else:
+        recommender = CatalogRecommender(sp)
+
+    # Surface the active engine at INFO (model included for the LLM engines) so the
+    # logs always show which recommender served a build, not just its output.
+    model = {"gemini": settings.gemini_model, "claude": settings.claude_model}.get(engine)
+    logger.info(
+        "Recommender engine: %s%s",
+        ENGINE_LABELS.get(engine, engine),
+        f" ({model})" if model else "",
+    )
+    return recommender

--- a/backend/core/recommender/gemini.py
+++ b/backend/core/recommender/gemini.py
@@ -15,7 +15,7 @@ import time
 from pydantic import BaseModel
 
 from backend.common.logging_config import logger
-from .base import Recommender, RecommenderError, Seed, Suggestion
+from .base import Recommender, RecommenderError, Seed, Suggestion, preview
 
 # Over-request multiplier: ask for ~25% more than needed so resolver misses
 # (hallucinated songs, punctuation mismatches) still leave enough real tracks.
@@ -67,6 +67,11 @@ class GeminiRecommender(Recommender):
 
         ask = max(count, int(count * _OVER_REQUEST))
         prompt = self._build_prompt(seeds, ask)
+        logger.debug(
+            "Gemini: requesting %d suggestions (model=%s, temp=%s) from %d seeds: %s",
+            ask, self._model, self._temperature, len(seeds), preview(seeds),
+        )
+        logger.debug("Gemini prompt:\n%s", prompt)
         config = types.GenerateContentConfig(
             response_mime_type="application/json",
             response_schema=list[_SuggestionSchema],
@@ -79,10 +84,17 @@ class GeminiRecommender(Recommender):
         client = self._get_client()
         for attempt in range(1, _MAX_RETRIES + 1):
             try:
+                started = time.perf_counter()
                 response = client.models.generate_content(
                     model=self._model, contents=prompt, config=config
                 )
-                return self._parse(response)
+                suggestions = self._parse(response)
+                logger.debug(
+                    "Gemini: %d usable suggestions in %.2fs (attempt %d): %s",
+                    len(suggestions), time.perf_counter() - started, attempt,
+                    preview(suggestions),
+                )
+                return suggestions
             except Exception as exc:  # noqa: BLE001 — degrade, don't crash a playlist build
                 retryable = _is_retryable(exc)
                 logger.warning(

--- a/backend/core/recommender/lastfm.py
+++ b/backend/core/recommender/lastfm.py
@@ -18,7 +18,7 @@ from concurrent.futures import ThreadPoolExecutor
 import requests
 
 from backend.common.logging_config import logger
-from .base import Recommender, Seed, Suggestion
+from .base import Recommender, Seed, Suggestion, preview
 
 _API = "https://ws.audioscrobbler.com/2.0/"
 _WORKERS = max(1, int(os.getenv("LASTFM_WORKERS", "5")))
@@ -48,11 +48,19 @@ class LastfmRecommender(Recommender):
         )
         out = _parse_similar_tracks(data)
         if out:
+            logger.debug(
+                "Last.fm: %d similar tracks for seed %s — %s", len(out), seed.title, seed.artist
+            )
             return out
         # Fallback: the seed track wasn't found / had no neighbours — surface more of
         # the same artist so the seed still contributes something.
         top = self._get("artist.gettoptracks", artist=seed.artist, limit=10)
-        return _parse_top_tracks(top)
+        fallback = _parse_top_tracks(top)
+        logger.debug(
+            "Last.fm: no neighbours for seed %s — %s; fell back to %d artist top tracks",
+            seed.title, seed.artist, len(fallback),
+        )
+        return fallback
 
     def recommend(self, seeds: list[Seed], count: int) -> list[Suggestion]:
         if not seeds or count <= 0:
@@ -79,6 +87,9 @@ class LastfmRecommender(Recommender):
         ask = max(count, int(count * _OVER_REQUEST))
         out = ranked[:ask]
         logger.info("Last.fm produced %d candidates from %d seeds.", len(out), len(seeds))
+        logger.debug(
+            "Last.fm top candidates (by aggregate match score): %s", preview(out)
+        )
         return out
 
 

--- a/backend/core/resolver.py
+++ b/backend/core/resolver.py
@@ -17,7 +17,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 
 from backend.common.logging_config import logger
-from .recommender.base import Suggestion
+from .recommender.base import Suggestion, preview
 from .resolver_cache import cache
 
 # Empirically the sweet spot: 5 workers ≈ 5x faster, no rate-limit hits; 10 was
@@ -35,7 +35,7 @@ def resolve_one(sp, suggestion: Suggestion) -> str | None:
         f'track:"{suggestion.title}" artist:"{suggestion.artist}"',  # strict
         f"{suggestion.title} {suggestion.artist}",                   # loose fallback
     )
-    for q in queries:
+    for kind, q in zip(("strict", "loose"), queries):
         try:
             res = sp.search(q=q, type="track", limit=1)
         except Exception as exc:  # noqa: BLE001 — one bad search shouldn't kill the batch
@@ -43,7 +43,13 @@ def resolve_one(sp, suggestion: Suggestion) -> str | None:
             continue
         items = res.get("tracks", {}).get("items", [])
         if items:
-            return items[0]["uri"]
+            uri = items[0]["uri"]
+            logger.debug(
+                "Resolved %s — %s via %s query -> %s",
+                suggestion.title, suggestion.artist, kind, uri,
+            )
+            return uri
+    logger.debug("No Spotify match for %s — %s", suggestion.title, suggestion.artist)
     return None
 
 
@@ -52,6 +58,7 @@ def _resolve_cached(sp, suggestion: Suggestion) -> str | None:
     key = _key(suggestion)
     hit = cache.get(key)
     if hit is not None:
+        logger.debug("Resolver cache hit: %s — %s -> %s", suggestion.title, suggestion.artist, hit)
         return hit
     uri = resolve_one(sp, suggestion)
     if uri:
@@ -82,11 +89,23 @@ def resolve_all(
             unique.append(s)
     if not unique:
         return []
+    logger.debug(
+        "Resolver: %d suggestions, %d unique after dedupe", len(suggestions), len(unique)
+    )
 
     # 2) Resolve (cache hit or Spotify search) on a bounded pool; map preserves order.
     with ThreadPoolExecutor(max_workers=min(max_workers, len(unique))) as pool:
         resolved = list(pool.map(lambda s: _resolve_cached(sp, s), unique))
     cache.flush()
+
+    # Surface the suggestions that found no Spotify match (LLM hallucinations, typos,
+    # regional gaps) — the main reason a build comes up short.
+    unresolved = [s for s, uri in zip(unique, resolved) if uri is None]
+    if unresolved:
+        logger.debug(
+            "Resolver: %d/%d suggestions had no Spotify match: %s",
+            len(unresolved), len(unique), preview(unresolved),
+        )
 
     # 3) De-dupe URIs, drop excluded, slice to limit.
     seen_uris: set[str] = set(exclude_uris or set())

--- a/backend/core/resolver_cache.py
+++ b/backend/core/resolver_cache.py
@@ -67,6 +67,7 @@ class ResolverCache:
                 tmp.write_text(json.dumps(self._data))
                 tmp.replace(self._path)  # atomic
                 self._dirty = False
+                logger.debug("Resolver cache flushed (%d entries total).", len(self._data))
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Resolver cache save failed: %s", exc)
 

--- a/backend/core/spotify_client.py
+++ b/backend/core/spotify_client.py
@@ -12,7 +12,7 @@ import os
 import random
 
 from backend.common.logging_config import logger
-from .recommender.base import Seed
+from .recommender.base import Seed, preview
 
 # How many seed tracks to feed the recommender. More seeds = broader taste coverage;
 # past ~50 it's diminishing returns + slower (one Last.fm call per seed). Env-tunable.
@@ -100,6 +100,7 @@ class SpotifyClient:
         random.shuffle(seeds)
         chosen = seeds[:limit]
         logger.info("Seeded from %d top tracks (%d available).", len(chosen), len(seeds))
+        logger.debug("Top-track seeds: %s", preview(chosen))
         return chosen
 
     def playlist_seeds(self, playlist_id: str, limit: int = _MAX_SEEDS) -> list[Seed]:
@@ -132,6 +133,7 @@ class SpotifyClient:
         n = min(limit, len(entries))
         chosen = _recency_weighted_sample([seed for seed, _ in entries], n)
         logger.info("Seeded from %d of %d playlist tracks (recency-weighted).", len(chosen), len(entries))
+        logger.debug("Playlist seeds (recency-weighted): %s", preview(chosen))
         return chosen
 
     # --- playlist reads ---

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -20,6 +20,8 @@ class PlaylistItem(BaseModel):
     total_tracks: int
     image_url: str
     recently_played: bool = False
+    # True for playlists this app made (daily/weekly/created-from) — drives the UI tabs.
+    created_by_app: bool = False
 
 
 class PlaylistsResponse(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ requests==2.32.5
 google-genai==2.9.0
 anthropic==0.111.0
 python-dotenv==1.0.1
+colorlog==6.9.0

--- a/backend/routers/playlists.py
+++ b/backend/routers/playlists.py
@@ -38,6 +38,7 @@ def list_playlists(client: SpotifyClient = Depends(get_client)) -> PlaylistsResp
                     total_tracks=p["tracks"]["total"],
                     image_url=images[0]["url"] if images else DEFAULT_IMAGE_URL,
                     recently_played=p.get("id") in recent_rank,
+                    created_by_app=playlist_ops.is_app_created(p["name"], p.get("description")),
                 )
             )
         except (KeyError, TypeError) as exc:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,12 +15,12 @@ services:
     ports:
       - "5471:80"
     env_file:
-      - ./backend/.env   # your real CLIENT_ID/SECRET/GEMINI_API_KEY/SESSION_SECRET
+      - ./.env   # your real CLIENT_ID/SECRET/GEMINI_API_KEY/SESSION_SECRET
     environment:
       - TZ=America/New_York
       # DEV_AUTH bypasses OAuth, so REDIRECT_URI is unused — reach this at http://<lan-ip>:5471.
       - REDIRECT_URI=http://127.0.0.1:5471/callback
-      # Refresh-token login bypass for headless/LAN dev (DEV_REFRESH_TOKEN in backend/.env).
+      # Refresh-token login bypass for headless/LAN dev (DEV_REFRESH_TOKEN in ./.env).
       - DEV_AUTH=true
       - LOG_LEVEL=DEBUG
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     container_name: spotifyproject
     ports:
       - "5470:80"
-    # Secrets live in backend/.env (gitignored); see backend/.env.example.
+    # Secrets live in ./.env at the project root (gitignored); see .env.example.
     # Convention: credentials in .env, non-secret config inline below.
     env_file:
-      - ./backend/.env   # CLIENT_ID, CLIENT_SECRET, SESSION_SECRET, GEMINI_API_KEY
+      - ./.env   # CLIENT_ID, CLIENT_SECRET, SESSION_SECRET, GEMINI_API_KEY
     environment:
       - TZ=America/New_York
       # Must EXACTLY match a Redirect URI registered on the Spotify app AND the

--- a/frontend/js/playlistActions.js
+++ b/frontend/js/playlistActions.js
@@ -11,6 +11,7 @@ export function playlistActions() {
     playlists: [],
     playlistsLoading: false,
     playlistSearch: '',
+    playlistTab: 'library',     // 'library' (user's own) | 'app' (made by this app)
     sourceDropdownOpen: false,  // create-from-playlist source picker
     sourceSearch: '',
     actionLoading: false, // global mutex: one mutating action at a time
@@ -21,10 +22,19 @@ export function playlistActions() {
     // Plain methods, not getters: this object is SPREAD into the Alpine root
     // (...playlistActions()), and the spread operator evaluates getters once and
     // copies their value as a static property (freezing them). Methods copy fine.
+    // Playlists in the active tab (library = the user's own; app = made by this app),
+    // then narrowed by the search box.
     filteredPlaylists() {
       const q = this.playlistSearch.trim().toLowerCase();
-      if (!q) return this.playlists;
-      return this.playlists.filter((p) => p.name.toLowerCase().includes(q));
+      return this.playlistsInTab(this.playlistTab).filter(
+        (p) => !q || p.name.toLowerCase().includes(q),
+      );
+    },
+    playlistsInTab(tab) {
+      return this.playlists.filter((p) => (tab === 'app' ? p.created_by_app : !p.created_by_app));
+    },
+    tabCount(tab) {
+      return this.playlistsInTab(tab).length;
     },
     totalTracks() {
       return this.playlists.reduce((n, p) => n + (p.total_tracks || 0), 0);

--- a/frontend/js/playlistActions.js
+++ b/frontend/js/playlistActions.js
@@ -45,11 +45,13 @@ export function playlistActions() {
 
     // ── Actions ────────────────────────────────────────────────────────────
     async createDaily() {
-      await this._runAction('daily', api.createDaily, 'Building your daily mix…');
+      await this._runAction('daily', api.createDaily, 'Building your daily mix…',
+        () => this.loadPlaylists());  // reflect the new playlist in the browser
     },
 
     async extendWeekly() {
-      await this._runAction('weekly', api.extendWeekly, 'Extending your weekly playlist…');
+      await this._runAction('weekly', api.extendWeekly, 'Extending your weekly playlist…',
+        () => this.loadPlaylists());  // weekly may have just been created
     },
 
     async deleteDaily() {
@@ -60,7 +62,8 @@ export function playlistActions() {
         danger: true,
       });
       if (!ok) return;
-      await this._runAction('delete', api.deleteDaily, 'Deleting daily playlists…');
+      await this._runAction('delete', api.deleteDaily, 'Deleting daily playlists…',
+        () => this.loadPlaylists());  // drop the deleted playlists from the browser
     },
 
     async createFromPlaylist() {

--- a/frontend/partials/playlist-browser.html
+++ b/frontend/partials/playlist-browser.html
@@ -15,6 +15,23 @@
     </div>
   </div>
 
+  <!-- Tabs: Spotify-style filter chips. The active chip uses the app accent (matching the
+       playlist-card selection state); the others stay quiet until hovered. -->
+  <div x-show="playlists.length && !playlistsLoading" class="flex items-center gap-2 mb-5">
+    <template x-for="tab in [{ id: 'library', label: 'Your library' }, { id: 'app', label: 'Made here' }]" :key="tab.id">
+      <button @click="playlistTab = tab.id" type="button"
+              class="px-4 py-1.5 rounded-full text-sm transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/60"
+              :class="playlistTab === tab.id
+                ? 'bg-accent-500 text-gray-950 font-semibold shadow-sm shadow-accent-500/30'
+                : 'bg-gray-800/80 text-gray-300 font-medium hover:bg-gray-700 hover:text-white'">
+        <span x-text="tab.label"></span>
+        <span class="ml-1 tabular-nums"
+              :class="playlistTab === tab.id ? 'text-gray-950/60' : 'text-gray-500'"
+              x-text="tabCount(tab.id)"></span>
+      </button>
+    </template>
+  </div>
+
   <!-- Loading skeleton -->
   <div x-show="playlistsLoading" class="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
     <template x-for="i in 8" :key="i">
@@ -26,13 +43,21 @@
     </template>
   </div>
 
-  <!-- Empty -->
+  <!-- Empty: no playlists at all -->
   <div x-show="!playlistsLoading && !playlists.length" class="rounded-2xl border border-dashed border-gray-800 bg-gray-900/30 p-10 text-center text-gray-500">
     No playlists found in your library yet.
   </div>
 
+  <!-- Empty: have playlists, but none in the active tab / matching the search -->
+  <div x-show="!playlistsLoading && playlists.length && !filteredPlaylists().length"
+       class="rounded-2xl border border-dashed border-gray-800 bg-gray-900/30 p-10 text-center text-gray-500">
+    <span x-show="playlistSearch.trim()">No playlists match your search.</span>
+    <span x-show="!playlistSearch.trim() && playlistTab === 'app'">No app-made playlists yet — create a daily or weekly mix above.</span>
+    <span x-show="!playlistSearch.trim() && playlistTab === 'library'">No playlists in your library.</span>
+  </div>
+
   <!-- Grid -->
-  <div x-show="!playlistsLoading && playlists.length" class="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+  <div x-show="!playlistsLoading && filteredPlaylists().length" class="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
     <template x-for="p in filteredPlaylists()" :key="p.name">
       <div @click="selectSource(p.name, { scroll: true })" @keydown.enter="selectSource(p.name, { scroll: true })"
            role="button" tabindex="0" :title="`Use ${p.name} as the source`"


### PR DESCRIPTION
## Summary
- **Config:** project-root `./.env` is now the canonical location (`backend/.env` kept as a legacy fallback); compose files, README, and `.env.example` updated.
- **Logging:** replaced the hand-rolled logger with `colorlog` (colored console + daily rotating file), added a DEBUG layer across the build pipeline (recommender prompts/latency/results, resolver matches + unresolved list, cache hits, seeds, orchestration), and an INFO line for the active recommender engine.
- **Playlists:** new tabbed browser — "Your library" vs "Made here" — backed by a description marker stamped on app-created playlists (with a name-heuristic backfill), a `created_by_app` flag on the list endpoint, and Spotify-style filter-chip tabs. Also refresh the browser after daily/weekly create + delete.

## Notes
- No CI runs on PRs (build only fires on push to `main`).