### PR TITLE
Header: active engine on mobile + icon logout

### DIFF
--- a/frontend/partials/header.html
+++ b/frontend/partials/header.html
@@ -14,10 +14,11 @@
         <span class="w-1.5 h-1.5 rounded-full bg-ok-400"></span> Connected
       </span>
 
-      <!-- Active recommendation engine; click to jump straight to the selector. -->
+      <!-- Active recommendation engine; click to jump straight to the selector.
+           Shown on mobile too — it's the only place the active engine surfaces there. -->
       <button x-show="authenticated && activeEngine()" @click="showSettings = true"
               :title="`Recommendation engine: ${engineLabel(activeEngine())} — click to change`"
-              class="hidden sm:inline-flex items-center gap-1.5 text-xs text-accent-300 bg-accent-500/10 border border-accent-800/50 hover:border-accent-600 rounded-full px-2.5 py-1 transition-colors">
+              class="inline-flex items-center gap-1.5 text-xs text-accent-300 bg-accent-500/10 border border-accent-800/50 hover:border-accent-600 rounded-full px-2.5 py-1 transition-colors">
         <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M19 3.1c.2 1.65.95 2.4 2.6 2.6-1.65.2-2.4.95-2.6 2.6-.2-1.65-.95-2.4-2.6-2.6 1.65-.2 2.4-.95 2.6-2.6z"/><rect x="3" y="13" width="3" height="7" rx="1.5"/><rect x="8" y="9" width="3" height="11" rx="1.5"/><rect x="13" y="11" width="3" height="9" rx="1.5"/></svg>
         <span x-text="activeEngine()?.label"></span>
       </button>
@@ -27,9 +28,12 @@
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
       </button>
 
-      <button x-show="authenticated" @click="logout()"
-              class="text-sm text-gray-300 hover:text-white bg-gray-800/70 hover:bg-gray-700 border border-gray-700 rounded-lg px-3 py-1.5 transition-colors">
-        Log out
+      <!-- Log out — icon-only (door + arrow), matching the -lens apps; frees header room. -->
+      <button x-show="authenticated" @click="logout()" aria-label="Log out" title="Log out"
+              class="group grid place-items-center w-9 h-9 rounded-lg text-gray-400 hover:bg-gray-800 transition-colors">
+        <svg class="w-5 h-5 group-hover:text-danger-400 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+        </svg>
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Active recommendation-engine pill now shows on all screen sizes (was desktop-only) — mobile gets the same active-mode indicator as desktop.
- "Log out" text button replaced with the door+arrow icon used in the -lens apps (red hover), which frees the header space mobile needs.