### PR TITLE
Vibe quality + mobile polish

### DIFF
--- a/backend/core/recommender/claude.py
+++ b/backend/core/recommender/claude.py
@@ -71,10 +71,22 @@ class ClaudeRecommender(Recommender):
             else " Leave playlist_name and playlist_description empty."
         )
         return (
-            "You are a music curator. Build a playlist that matches this description from "
-            f'the listener: "{description}". Suggest {count} real, currently-existing songs '
-            "that fit the requested mood, genre, era, and energy. Vary the artists and do "
-            f"not invent songs that do not exist.{naming}"
+            "You are an expert music curator. Build a tightly cohesive playlist for this "
+            f'listener request: "{description}".\n\n'
+            "First read the request for its specific intent — genre/sub-genre, mood, energy "
+            "or intensity level, era, and any activity or setting. Then suggest up to "
+            f"{count} real, currently-existing songs where EVERY track clearly fits ALL of "
+            "those dimensions.\n\n"
+            "Rules:\n"
+            "- Cohesion beats variety. Every song must match the requested energy and mood: "
+            "a high-energy/aggressive request gets zero mellow, chill, or sentimental "
+            "tracks, and vice versa. When in doubt, leave it out.\n"
+            "- Never pad. If you cannot find enough songs that strongly fit, return fewer — "
+            "a shorter on-vibe playlist beats a padded one with off-vibe filler.\n"
+            "- Prefer different artists, but only among songs that already fit; never trade "
+            "fit for variety.\n"
+            "- Only real songs that actually exist; do not invent titles or artists."
+            f"{naming}"
         )
 
     @staticmethod

--- a/backend/core/recommender/gemini.py
+++ b/backend/core/recommender/gemini.py
@@ -22,6 +22,14 @@ from .base import Recommender, RecommenderError, Seed, Suggestion, VibeResult, p
 _OVER_REQUEST = 1.25
 _MAX_RETRIES = 3
 
+# Vibe builds are quality-sensitive, not latency-sensitive: tighten the engine so it
+# sticks to the requested mood instead of drifting. A lower temperature trims the
+# off-vibe randomness that 1.0 invites, and a small thinking budget lets flash actually
+# reason about whether each track fits before committing (vs. the thinking_budget=0 we
+# use on seed-based recommend, where we want speed + variety).
+_VIBE_TEMPERATURE = 0.7
+_VIBE_THINKING_BUDGET = 512
+
 
 class _SuggestionSchema(BaseModel):
     """Shape Gemini must return for each item (drives `response_schema`)."""
@@ -77,10 +85,22 @@ class GeminiRecommender(Recommender):
             else " Leave playlist_name and playlist_description empty."
         )
         return (
-            "You are a music curator. Build a playlist that matches this description from "
-            f'the listener: "{description}". Suggest {count} real, currently-existing songs '
-            "that fit the requested mood, genre, era, and energy. Vary the artists and do "
-            f"not invent songs that do not exist.{naming}"
+            "You are an expert music curator. Build a tightly cohesive playlist for this "
+            f'listener request: "{description}".\n\n'
+            "First read the request for its specific intent — genre/sub-genre, mood, energy "
+            "or intensity level, era, and any activity or setting. Then suggest up to "
+            f"{count} real, currently-existing songs where EVERY track clearly fits ALL of "
+            "those dimensions.\n\n"
+            "Rules:\n"
+            "- Cohesion beats variety. Every song must match the requested energy and mood: "
+            "a high-energy/aggressive request gets zero mellow, chill, or sentimental "
+            "tracks, and vice versa. When in doubt, leave it out.\n"
+            "- Never pad. If you cannot find enough songs that strongly fit, return fewer — "
+            "a shorter on-vibe playlist beats a padded one with off-vibe filler.\n"
+            "- Prefer different artists, but only among songs that already fit; never trade "
+            "fit for variety.\n"
+            "- Only real songs that actually exist; do not invent titles or artists."
+            f"{naming}"
         )
 
     def recommend(self, seeds: list[Seed], count: int) -> list[Suggestion]:
@@ -148,8 +168,8 @@ class GeminiRecommender(Recommender):
         config = types.GenerateContentConfig(
             response_mime_type="application/json",
             response_schema=_VibeSchema,
-            temperature=self._temperature,
-            thinking_config=types.ThinkingConfig(thinking_budget=0),
+            temperature=_VIBE_TEMPERATURE,  # tighter than seed-based recommend — see top
+            thinking_config=types.ThinkingConfig(thinking_budget=_VIBE_THINKING_BUDGET),
         )
 
         client = self._get_client()

--- a/frontend/partials/create-from-playlist.html
+++ b/frontend/partials/create-from-playlist.html
@@ -7,11 +7,14 @@
       <svg class="w-5 h-5 text-accent-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
       <h2 class="font-display text-lg font-bold">Create a playlist</h2>
     </div>
-    <!-- Segmented mode toggle — hidden entirely when no LLM is available for vibe mode. -->
-    <div x-show="vibe.available.length" class="inline-flex rounded-lg border border-gray-800 bg-gray-950 p-1">
-      <button @click="createMode = 'vibe'; createModeTouched = true" class="px-3 py-1.5 text-sm rounded-md transition-colors"
+    <!-- Segmented mode toggle — hidden entirely when no LLM is available for vibe mode.
+         On mobile it wraps to its own full-width row (each button flex-1) so it reads as
+         an intentional segmented control instead of being shoved/cramped beside the title;
+         on sm+ it shrinks back to an inline pill on the right. -->
+    <div x-show="vibe.available.length" class="inline-flex w-full sm:w-auto rounded-lg border border-gray-800 bg-gray-950 p-1">
+      <button @click="createMode = 'vibe'; createModeTouched = true" class="flex-1 sm:flex-none text-center px-3 py-1.5 text-sm rounded-md transition-colors"
               :class="createMode === 'vibe' ? 'bg-accent-500 text-gray-950 font-medium' : 'text-gray-400 hover:text-white'">From a vibe</button>
-      <button @click="createMode = 'playlist'; createModeTouched = true" class="px-3 py-1.5 text-sm rounded-md transition-colors"
+      <button @click="createMode = 'playlist'; createModeTouched = true" class="flex-1 sm:flex-none text-center px-3 py-1.5 text-sm rounded-md transition-colors"
               :class="createMode === 'playlist' ? 'bg-accent-500 text-gray-950 font-medium' : 'text-gray-400 hover:text-white'">From a playlist</button>
     </div>
   </div>
@@ -93,7 +96,7 @@
 
   <!-- ── Mode: from a vibe (free text → LLM) ────────────────────────────── -->
   <div x-show="createMode === 'vibe'" x-cloak>
-    <p class="text-sm text-gray-400 mb-3">Describe the playlist you want in plain words — an LLM picks songs to match, every one verified on Spotify.</p>
+    <p class="text-sm text-gray-400 mb-3">Describe a vibe — an LLM picks matching songs, each verified on Spotify.</p>
 
     <textarea x-model="vibeForm.description" rows="2" maxlength="300"
               placeholder="e.g. rainy sunday coffee-shop jazz · upbeat 2000s indie for a workout"

--- a/frontend/partials/toast.html
+++ b/frontend/partials/toast.html
@@ -11,7 +11,7 @@
      x-transition:leave="transition ease-in duration-150"
      x-transition:leave-start="opacity-100 translate-y-0"
      x-transition:leave-end="opacity-0 -translate-y-2"
-     class="fixed top-20 left-1/2 -translate-x-1/2 z-[1500] w-[calc(100%-1.5rem)] max-w-md">
+     class="fixed top-20 left-1/2 -translate-x-1/2 transform-gpu will-change-transform z-[1500] w-[calc(100%-1.5rem)] max-w-md">
   <div :class="actionResult?.ok ? 'bg-ok-900/90 border-ok-700 text-ok-100' : 'bg-danger-900/90 border-danger-700 text-danger-100'"
        class="flex items-start justify-between gap-3 px-3.5 py-3 border rounded-xl text-sm shadow-xl backdrop-blur-md">
     <div class="flex items-start gap-2 min-w-0">


### PR DESCRIPTION
## Vibe recommendation quality
- **Shared prompt rewrite (Claude + Gemini):** cohesion is now a hard constraint — every track must match the requested energy/mood, padding is forbidden ("return fewer rather than off-vibe filler"), and "vary the artists" is demoted to a soft preference applied only among songs that already fit. Targets the off-vibe junk (e.g. a chill track landing in a "rage gym dubstep" build), which showed on both Sonnet and Gemini flash.
- **Gemini vibe path tightened:** temperature `1.0 → 0.7` and a `512`-token thinking budget so flash reasons about fit before committing. Seed-based `recommend()` is untouched (keeps temp 1.0 / no thinking for variety + latency).

## Mobile polish
- **Create-mode toggle** ("From a vibe / From a playlist") becomes a full-width segmented control on its own row on mobile (`flex-1` buttons), shrinking to an inline pill on `sm+` — no more cramped wrap.
- **Trimmed** the vibe-mode helper copy so it stops spanning multiple lines on mobile.
- **Toast** promoted to its own GPU compositor layer (`transform-gpu` / `will-change-transform`) so iOS Safari keeps it pinned to the viewport instead of scrolling it off the top.

https://claude.ai/code/session_013HKe29AmcgVrLmeTw19boi