### PR TITLE
Vibe: hybrid Last.fm blend + tighten resolver artist matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ celerybeat.pid
 .spotify-api
 .lastfm-api
 .anthropic-api
+.sample-model-responses
 
 # Personal planning doc — local only
 PLANNING.md

--- a/backend/core/playlists.py
+++ b/backend/core/playlists.py
@@ -41,6 +41,16 @@ _MAX_PLAYLIST_SONGS = 200
 # date-named-daily heuristic in is_app_created clear of vibe playlists.
 _VIBE_NAME_MAX = 40
 
+# Hybrid vibe build (see PLANNING §12.2): the LLM interprets the vibe and supplies a clean
+# *core* (its top picks); Last.fm similarity grounds and extends it. A/B/C testing showed the
+# LLM over-concentrates on a few artists and drifts as it pads for count, while a Last.fm fill
+# seeded by the LLM's clean head adds on-vibe variety — so we deliberately cap the LLM core at
+# ~60% of the target and fill the rest, rather than only filling when the LLM comes up short.
+# Thin cores are protected by the same ratio: fill never outweighs the core (it stays a
+# majority), so a niche vibe yields a shorter playlist instead of a fill-dominated, drifty one.
+_VIBE_CORE_FRACTION = 0.6   # LLM provides ~60% of the playlist; Last.fm fills the remainder
+_VIBE_FILL_SEED_HEAD = 15   # how many top core tracks to seed Last.fm with
+
 # Matches the daily naming format (e.g. "Jun-23-2026") — used to recognize dailies
 # created before the description marker existed.
 _DAILY_NAME_RE = re.compile(r"^[A-Z][a-z]{2}-\d{2}-\d{4}$")
@@ -171,6 +181,65 @@ def _vibe_fallback_name(description: str) -> str:
     return f"Vibe: {text}" if text else "Vibe playlist"
 
 
+def _seeds_from_uris(client: SpotifyClient, uris: list[str]) -> list[Seed]:
+    """Resolve verified track URIs back to {title, artist} seeds for the fill engine —
+    canonical Spotify metadata makes cleaner Last.fm seeds than the LLM's raw titles."""
+    if not uris:
+        return []
+    try:
+        tracks = client.sp.tracks(uris).get("tracks", [])
+    except Exception as exc:  # noqa: BLE001 — fill is best-effort; skip it on a lookup failure
+        logger.warning("Vibe fill: seed lookup failed, skipping fill: %s", exc)
+        return []
+    seeds: list[Seed] = []
+    for t in tracks:
+        if not t:
+            continue
+        title = (t.get("name") or "").strip()
+        artists = t.get("artists") or []
+        artist = (artists[0].get("name") or "").strip() if artists else ""
+        if title and artist:
+            seeds.append(Seed(title, artist))
+    return seeds
+
+
+def _hybrid_blend(
+    client: SpotifyClient, fill_recommender: Recommender, llm_uris: list[str], target: int
+) -> list[str]:
+    """Blend the LLM's clean *core* with a grounded Last.fm fill (the "B" strategy).
+
+    Takes the LLM's top ~`_VIBE_CORE_FRACTION` of the target as the core (its highest-ranked,
+    cleanest picks — the drift and artist over-concentration show up further down the list),
+    then fills the rest from Last.fm similarity seeded by the head of that core. Last.fm's
+    cross-seed aggregation extends the vibe with real, co-listened tracks (grounded, no
+    hallucination) and broadens artist variety. The fill never outweighs the core — the final
+    total is capped at `core / _VIBE_CORE_FRACTION` — so a thin core (niche vibe the LLM
+    couldn't fill) yields a shorter playlist rather than a fill-dominated, drifty one.
+
+    Best-effort: any Last.fm/lookup miss just returns the core as-is."""
+    core = llm_uris[: max(1, round(target * _VIBE_CORE_FRACTION))]
+    # Keep the LLM core a majority: cap the total at core / fraction (≈ target for a healthy
+    # core, less for a thin one), and never exceed the requested target.
+    max_total = min(target, round(len(core) / _VIBE_CORE_FRACTION))
+    need = max_total - len(core)
+    if need <= 0:
+        return core
+    seeds = _seeds_from_uris(client, core[:_VIBE_FILL_SEED_HEAD])
+    if not seeds:
+        return core
+    logger.debug(
+        "Vibe hybrid: LLM core=%d (of %d resolved), filling %d from Last.fm (target=%d)",
+        len(core), len(llm_uris), need, target,
+    )
+    suggestions = fill_recommender.recommend(seeds, need)
+    fill = resolve_all(client.sp, suggestions, limit=need, exclude_uris=set(core))
+    logger.info(
+        "Vibe hybrid: %d LLM core + %d Last.fm fill = %d tracks (target %d).",
+        len(core), len(fill), len(core) + len(fill), target,
+    )
+    return core + fill
+
+
 def create_vibe_playlist(
     client: SpotifyClient,
     recommender: VibeRecommender,
@@ -178,10 +247,15 @@ def create_vibe_playlist(
     count: int = DEFAULT_VIBE_COUNT,
     *,
     name_it: bool = True,
+    fill_recommender: Recommender | None = None,
 ) -> PlaylistResult:
     """Build a playlist from a free-text vibe via an LLM. The engine returns the song
     suggestions plus (when `name_it`) a name/description; we resolve to real URIs and
-    write the playlist, falling back to a name derived from the vibe text if needed."""
+    write the playlist, falling back to a name derived from the vibe text if needed.
+
+    When `fill_recommender` is supplied (Last.fm), the build is a hybrid: the LLM's clean
+    core plus a grounded Last.fm fill — see `_hybrid_blend`. Off by default (None) so callers
+    without a Last.fm key get the raw LLM list unchanged."""
     description = description.strip()
     if not description:
         raise ValueError("Describe the vibe you want before generating.")
@@ -192,6 +266,11 @@ def create_vibe_playlist(
     uris = resolve_all(client.sp, result.suggestions, limit=count)
     if not uris:
         raise ValueError("No playable songs were found for that vibe. Try rewording it.")
+    # Hybrid blend: keep the LLM's clean core, ground/extend the rest from Last.fm (more
+    # cohesion + artist variety than letting the LLM pad for count). Falls through to the raw
+    # LLM list when no Last.fm key is configured.
+    if fill_recommender is not None:
+        uris = _hybrid_blend(client, fill_recommender, uris, count)
     random.shuffle(uris)
 
     name = result.name if (name_it and result.name) else _vibe_fallback_name(description)

--- a/backend/core/resolver.py
+++ b/backend/core/resolver.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import os
 import re
+import unicodedata
 from concurrent.futures import ThreadPoolExecutor
 
 from backend.common.logging_config import logger
@@ -43,11 +44,15 @@ _ARTIST_SPLIT = re.compile(r"\s*(?:&|,|/|\bfeat\.?\b|\bft\.?\b|\bx\b|\bvs\.?\b)\
 # A leading "Something - " the LLM prepends from a series/source ("Destroid 5 - Crowd
 # Control", "Deadmau5 - Fn Pig") that isn't part of the real track title.
 _TITLE_PREFIX = re.compile(r"^.{1,40}?\s+-\s+(?=\S)")
+# A leading "The " dropped when comparing artists, so "The Beatles" == "Beatles".
+_LEADING_THE = re.compile(r"^the\s+", re.I)
 
 
 def _norm(s: str) -> str:
-    """Lowercase + strip everything but alphanumerics, so 'NGHTMRE' == 'Nghtmre',
-    'Deadmau5' == 'deadmau5', and 'Brain Dead' == 'Braindead' when comparing."""
+    """Lowercase, transliterate accents (é→e, ÿ→y), strip everything but alphanumerics —
+    so 'NGHTMRE' == 'Nghtmre', 'Deadmau5' == 'deadmau5', 'Beyoncé' == 'Beyonce', and
+    'JAŸ-Z' == 'Jay-Z' when comparing."""
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
     return re.sub(r"[^a-z0-9]", "", s.lower())
 
 
@@ -72,15 +77,26 @@ def _title_variants(title: str) -> list[str]:
     return list(dict.fromkeys(v for v in variants if v))
 
 
+def _artist_key(s: str) -> str:
+    """Comparison key for an artist name: `_norm` with a leading 'The ' dropped, so
+    'The Beatles' == 'Beatles'."""
+    return _norm(_LEADING_THE.sub("", s.strip()))
+
+
 def _artist_matches(suggested_artist: str, track_artists: list[str]) -> bool:
     """True if the suggestion's artist genuinely corresponds to the track Spotify
     returned. A search will happily return its top hit for *any* words ("Impulse
     NGHTMRE" → "Nightfall — Calmly"), so we reject a candidate whose artist doesn't
-    actually match — that's where the off-vibe junk came from. A token matches when
-    either name contains the other (handles "feat."/remix credit bloat)."""
-    suggested = [_norm(p) for p in _ARTIST_SPLIT.split(suggested_artist) if _norm(p)]
-    actual = [_norm(a) for a in track_artists if _norm(a)]
-    return any(s and a and (s in a or a in s) for s in suggested for a in actual)
+    match. We require an *exact* (normalized) name match, not a substring — substring
+    matching let "Excision" match the unrelated band "Indecent Excision". The whole
+    suggested string is checked first (so a name containing a split char, e.g.
+    "Tyler, The Creator", still matches), then each credited collaborator."""
+    actual = {_artist_key(a) for a in track_artists if _artist_key(a)}
+    if not actual:
+        return False
+    if _artist_key(suggested_artist) in actual:
+        return True
+    return any(_artist_key(p) in actual for p in _ARTIST_SPLIT.split(suggested_artist) if _artist_key(p))
 
 
 def _title_matches(suggested_title: str, track_title: str) -> bool:

--- a/backend/routers/playlists.py
+++ b/backend/routers/playlists.py
@@ -10,6 +10,7 @@ from backend.common.logging_config import logger
 from backend.core import playlists as playlist_ops
 from backend.core.recommender.base import Recommender, RecommenderError
 from backend.core.recommender.factory import build_recommender
+from backend.core.recommender.lastfm import LastfmRecommender
 from backend.core.spotify_client import SpotifyClient
 from backend.deps import (
     SESSION_VIBE_ENGINE_KEY,
@@ -118,9 +119,15 @@ def create_vibe(
     model = settings.resolve_model(engine, body.model)
     request.session[SESSION_VIBE_MODEL_KEY] = model
     recommender = build_recommender(settings, client.sp, engine, model)
+    # Grounded count-fill: when the LLM lands short, top up from Last.fm similarity rather
+    # than padding with more LLM guesses. Only available when a Last.fm key is configured.
+    fill_recommender = (
+        LastfmRecommender(settings.lastfm_api_key) if settings.lastfm_api_key else None
+    )
     res = _run(
         lambda: playlist_ops.create_vibe_playlist(
-            client, recommender, body.description, body.num_songs, name_it=body.name_it
+            client, recommender, body.description, body.num_songs,
+            name_it=body.name_it, fill_recommender=fill_recommender,
         )
     )
     return PlaylistMutationResponse(message=res.message, id=res.playlist_id, name=res.name, total_tracks=res.track_count)


### PR DESCRIPTION
## Hybrid Last.fm blend for vibe builds
Vibe playlists now blend an **LLM core** with a **grounded Last.fm fill** instead of leaning on the LLM for the whole count. A/B testing (PLANNING §12.2) showed the LLM over-concentrates on a few artists and drifts into adjacent genres as it pads toward the target; a Last.fm fill seeded from the LLM's clean head adds real, co-listened, on-vibe variety.

- **`core/playlists.py` — `_hybrid_blend`**: take the LLM's top ~60% of the target as the core, fill the rest from Last.fm similarity seeded by the core's head. The fill never outweighs the core (total capped at `core / 0.6`), so a niche vibe the LLM can't fill yields a *shorter* playlist rather than a fill-dominated, drifty one. Runs on every vibe build when a Last.fm key is configured; no key → raw LLM list unchanged.
- **`routers/playlists.py`**: wires a `LastfmRecommender` as the fill engine.

## Tighten resolver artist matching
- **`_artist_matches`**: exact normalized match instead of substring — substring let `"Excision"` match the unrelated band **"Indecent Excision"** (brutal death metal landing in a dubstep playlist). Whole suggested string checked first (so `"Tyler, The Creator"` still matches), then each collaborator; leading `"The"` dropped so `"The Beatles" == "Beatles"`.
- **`_norm`**: transliterate accents (é→e, ÿ→y) so `"JAŸ-Z" == "Jay-Z"`, `"Beyoncé" == "Beyonce"` — helps artist *and* title matching across the board.

## Validation
Validated on the local container: dubstep + peaceful-lake vibes blend cleanly (24 LLM + 16 Last.fm = 40), the fill stays on-vibe with no off-genre amplification, and mood is largely retained.

https://claude.ai/code/session_013HKe29AmcgVrLmeTw19boi