### PR TITLE
Vibe: optional 'remix a playlist' transform

### DIFF
--- a/backend/core/playlists.py
+++ b/backend/core/playlists.py
@@ -55,6 +55,13 @@ _VIBE_NAME_MAX = 40
 _VIBE_CORE_FRACTION = 0.6   # LLM provides ~60% of the playlist; Last.fm fills the remainder
 _VIBE_FILL_SEED_HEAD = 15   # how many top core tracks to seed Last.fm with
 
+# When a vibe build attaches a source playlist (the "transform" mode — regenerate this
+# playlist with a change applied), we hand the LLM a recency-weighted sample of that
+# playlist as reference. Capped higher than the default 50 seeds: more reference better
+# conveys a playlist's character, and `playlist_seeds` already scales the sample down for
+# smaller playlists, so 100 is a ceiling, not a fixed cost.
+_VIBE_SOURCE_SEED_MAX = 100
+
 # Matches the daily naming format (e.g. "Jun-23-2026") — used to recognize dailies
 # created before the description marker existed.
 _DAILY_NAME_RE = re.compile(r"^[A-Z][a-z]{2}-\d{2}-\d{4}$")
@@ -252,10 +259,15 @@ def create_vibe_playlist(
     *,
     name_it: bool = True,
     fill_recommender: Recommender | None = None,
+    source_playlist: str | None = None,
 ) -> PlaylistResult:
     """Build a playlist from a free-text vibe via an LLM. The engine returns the song
     suggestions plus (when `name_it`) a name/description; we resolve to real URIs and
     write the playlist, falling back to a name derived from the vibe text if needed.
+
+    When `source_playlist` is given, the build is a *transform*: a recency-weighted sample
+    of that playlist is handed to the LLM as reference and the vibe text is applied as a
+    change to it (regenerate, not edit — see `vibe_prompt`).
 
     When `fill_recommender` is supplied (Last.fm), the build is a hybrid: the LLM's clean
     core plus a grounded Last.fm fill — see `_hybrid_blend`. Off by default (None) so callers
@@ -265,7 +277,16 @@ def create_vibe_playlist(
         raise ValueError("Describe the vibe you want before generating.")
     count = max(1, min(count, _MAX_VIBE_SONGS))
 
-    result = recommender.recommend_vibe(description, count, name_it=name_it)
+    seeds = None
+    if source_playlist:
+        source_id = client.find_playlist_id(source_playlist)
+        if source_id is None:
+            raise ValueError(f"Source playlist '{source_playlist}' was not found.")
+        seeds = client.playlist_seeds(source_id, limit=_VIBE_SOURCE_SEED_MAX)
+        if not seeds:
+            raise ValueError(f"Source playlist '{source_playlist}' has no usable tracks to build from.")
+
+    result = recommender.recommend_vibe(description, count, name_it=name_it, seeds=seeds)
     logger.debug("Vibe pipeline: engine returned %d suggestions; resolving", len(result.suggestions))
     uris = resolve_all(client.sp, result.suggestions, limit=count)
     if not uris:

--- a/backend/core/recommender/base.py
+++ b/backend/core/recommender/base.py
@@ -74,7 +74,86 @@ class VibeRecommender(Protocol):
     Only the LLM engines implement this — interpreting natural language ("rainy sunday
     coffee-shop jazz") is exactly what the data engines (lastfm/catalog) structurally
     can't do. Same contract as `recommend`: over-request is allowed, "no results" returns
-    an empty `VibeResult`, and a hard engine failure raises `RecommenderError`."""
+    an empty `VibeResult`, and a hard engine failure raises `RecommenderError`.
 
-    def recommend_vibe(self, description: str, count: int, *, name_it: bool) -> VibeResult:
+    When `seeds` is given (a sample of an existing playlist), the build is a *transform*:
+    regenerate that playlist with the free-text instruction applied — see `vibe_prompt`."""
+
+    def recommend_vibe(
+        self, description: str, count: int, *, name_it: bool, seeds: list[Seed] | None = None
+    ) -> VibeResult:
         ...
+
+
+# The vibe-mode prompt is shared verbatim by every LLM engine (the model interprets the
+# request; only the API plumbing differs per engine), so it lives here rather than being
+# copy-pasted into each. Two variants: a pure free-text vibe, and — when `seeds` from an
+# existing playlist are supplied — a transform that regenerates that playlist with one change.
+_VIBE_QUALITY_RULES = (
+    "- Cohesion beats variety. Every song must match the requested energy and mood: "
+    "a high-energy/aggressive request gets zero mellow, chill, or sentimental "
+    "tracks, and vice versa. When in doubt, leave it out.\n"
+    "- Never pad. If you cannot find enough songs that strongly fit, return fewer — "
+    "a shorter on-vibe playlist beats a padded one with off-vibe filler.\n"
+    "- Prefer different artists, but only among songs that already fit; never trade "
+    "fit for variety.\n"
+    "- Only real, officially released songs available on major streaming "
+    "services — prefer original studio releases, and avoid bootleg remixes, "
+    "mashups, white-labels, and any title you are not confident exists. Do not "
+    "invent titles or artists."
+)
+
+
+def _naming_clause(name_it: bool) -> str:
+    return (
+        " Also provide a short, evocative playlist name (at most 40 characters) and a "
+        "single-sentence description that captures the vibe."
+        if name_it
+        else " Leave playlist_name and playlist_description empty."
+    )
+
+
+def vibe_prompt(
+    description: str, count: int, *, name_it: bool, seeds: list[Seed] | None = None
+) -> str:
+    """Build the vibe-mode prompt shared by all LLM engines.
+
+    Without `seeds`: a pure free-text vibe ("rainy sunday coffee-shop jazz"). With `seeds`
+    (a recency-weighted sample of an existing playlist): a *transform* — regenerate that
+    playlist with the instruction applied, shifting the dimension the listener named and
+    preserving the rest. Either way the same quality/anti-hallucination rules apply."""
+    naming = _naming_clause(name_it)
+    if seeds:
+        seed_lines = "\n".join(f"- {s.title} — {s.artist}" for s in seeds)
+        return (
+            "You are an expert music curator. The listener has an existing playlist and "
+            "wants a NEW playlist derived from it, with one change applied.\n\n"
+            f'Their instruction: "{description}".\n\n'
+            f"Reference playlist (a sample of its tracks):\n{seed_lines}\n\n"
+            "Read the reference playlist to understand its character — genre/sub-genre, "
+            "mood, energy or intensity level, era, and the kind of artists in it. Then "
+            "apply the instruction as a transformation: shift the dimension the listener "
+            "asked to change, and preserve everything they did NOT mention. Suggest up to "
+            f"{count} real, currently-existing songs for the transformed playlist.\n\n"
+            "Rules:\n"
+            "- This is a regeneration, not an edit. Suggest new tracks that fit the "
+            "transformed character. You may keep a few reference tracks where they still "
+            "fit, but do not simply copy the playlist.\n"
+            "- Honor the instruction decisively. 'Less hardcore' means clearly softer "
+            "across the whole playlist, not a couple of token mellow tracks.\n"
+            "- Preserve the un-mentioned character: keep the reference's genre family, era, "
+            "and overall taste except where the instruction overrides them.\n"
+            f"{_VIBE_QUALITY_RULES}"
+            f"{naming}"
+        )
+    return (
+        "You are an expert music curator. Build a tightly cohesive playlist for this "
+        f'listener request: "{description}".\n\n'
+        "First read the request for its specific intent — genre/sub-genre, mood, energy "
+        "or intensity level, era, and any activity or setting. Then suggest up to "
+        f"{count} real, currently-existing songs where EVERY track clearly fits ALL of "
+        "those dimensions.\n\n"
+        "Rules:\n"
+        f"{_VIBE_QUALITY_RULES}"
+        f"{naming}"
+    )

--- a/backend/core/recommender/claude.py
+++ b/backend/core/recommender/claude.py
@@ -14,7 +14,7 @@ import time
 from pydantic import BaseModel
 
 from backend.common.logging_config import logger
-from .base import Recommender, RecommenderError, Seed, Suggestion, VibeResult, preview
+from .base import Recommender, RecommenderError, Seed, Suggestion, VibeResult, preview, vibe_prompt
 
 _OVER_REQUEST = 1.25  # ask for ~25% more than needed to absorb resolver misses
 # Vibe builds over-request harder: the resolver now verifies artist match and rejects
@@ -67,36 +67,6 @@ class ClaudeRecommender(Recommender):
         )
 
     @staticmethod
-    def _build_vibe_prompt(description: str, count: int, name_it: bool) -> str:
-        naming = (
-            " Also provide a short, evocative playlist name (at most 40 characters) and a "
-            "single-sentence description that captures the vibe."
-            if name_it
-            else " Leave playlist_name and playlist_description empty."
-        )
-        return (
-            "You are an expert music curator. Build a tightly cohesive playlist for this "
-            f'listener request: "{description}".\n\n'
-            "First read the request for its specific intent — genre/sub-genre, mood, energy "
-            "or intensity level, era, and any activity or setting. Then suggest up to "
-            f"{count} real, currently-existing songs where EVERY track clearly fits ALL of "
-            "those dimensions.\n\n"
-            "Rules:\n"
-            "- Cohesion beats variety. Every song must match the requested energy and mood: "
-            "a high-energy/aggressive request gets zero mellow, chill, or sentimental "
-            "tracks, and vice versa. When in doubt, leave it out.\n"
-            "- Never pad. If you cannot find enough songs that strongly fit, return fewer — "
-            "a shorter on-vibe playlist beats a padded one with off-vibe filler.\n"
-            "- Prefer different artists, but only among songs that already fit; never trade "
-            "fit for variety.\n"
-            "- Only real, officially released songs available on major streaming "
-            "services — prefer original studio releases, and avoid bootleg remixes, "
-            "mashups, white-labels, and any title you are not confident exists. Do not "
-            "invent titles or artists."
-            f"{naming}"
-        )
-
-    @staticmethod
     def _to_suggestions(items: list[_Item]) -> list[Suggestion]:
         out: list[Suggestion] = []
         for item in items:
@@ -140,16 +110,18 @@ class ClaudeRecommender(Recommender):
         )
         return out
 
-    def recommend_vibe(self, description: str, count: int, *, name_it: bool) -> VibeResult:
+    def recommend_vibe(
+        self, description: str, count: int, *, name_it: bool, seeds: list[Seed] | None = None
+    ) -> VibeResult:
         description = (description or "").strip()
         if not description or count <= 0:
             return VibeResult(suggestions=[])
 
         ask = max(count, int(count * _VIBE_OVER_REQUEST))
-        prompt = self._build_vibe_prompt(description, ask, name_it)
+        prompt = vibe_prompt(description, ask, name_it=name_it, seeds=seeds)
         logger.debug(
-            "Claude vibe: requesting %d suggestions (model=%s, name_it=%s) for %r",
-            ask, self._model, name_it, description,
+            "Claude vibe: requesting %d suggestions (model=%s, name_it=%s, seeds=%d) for %r",
+            ask, self._model, name_it, len(seeds or ()), description,
         )
         logger.debug("Claude vibe prompt:\n%s", prompt)
         try:

--- a/backend/core/recommender/gemini.py
+++ b/backend/core/recommender/gemini.py
@@ -15,7 +15,7 @@ import time
 from pydantic import BaseModel
 
 from backend.common.logging_config import logger
-from .base import Recommender, RecommenderError, Seed, Suggestion, VibeResult, preview
+from .base import Recommender, RecommenderError, Seed, Suggestion, VibeResult, preview, vibe_prompt
 
 # Over-request multiplier: ask for ~25% more than needed so resolver misses
 # (hallucinated songs, punctuation mismatches) still leave enough real tracks.
@@ -80,36 +80,6 @@ class GeminiRecommender(Recommender):
             f"Seed tracks:\n{seed_lines}"
         )
 
-    @staticmethod
-    def _build_vibe_prompt(description: str, count: int, name_it: bool) -> str:
-        naming = (
-            " Also provide a short, evocative playlist name (at most 40 characters) and a "
-            "single-sentence description that captures the vibe."
-            if name_it
-            else " Leave playlist_name and playlist_description empty."
-        )
-        return (
-            "You are an expert music curator. Build a tightly cohesive playlist for this "
-            f'listener request: "{description}".\n\n'
-            "First read the request for its specific intent — genre/sub-genre, mood, energy "
-            "or intensity level, era, and any activity or setting. Then suggest up to "
-            f"{count} real, currently-existing songs where EVERY track clearly fits ALL of "
-            "those dimensions.\n\n"
-            "Rules:\n"
-            "- Cohesion beats variety. Every song must match the requested energy and mood: "
-            "a high-energy/aggressive request gets zero mellow, chill, or sentimental "
-            "tracks, and vice versa. When in doubt, leave it out.\n"
-            "- Never pad. If you cannot find enough songs that strongly fit, return fewer — "
-            "a shorter on-vibe playlist beats a padded one with off-vibe filler.\n"
-            "- Prefer different artists, but only among songs that already fit; never trade "
-            "fit for variety.\n"
-            "- Only real, officially released songs available on major streaming "
-            "services — prefer original studio releases, and avoid bootleg remixes, "
-            "mashups, white-labels, and any title you are not confident exists. Do not "
-            "invent titles or artists."
-            f"{naming}"
-        )
-
     def recommend(self, seeds: list[Seed], count: int) -> list[Suggestion]:
         if not seeds or count <= 0:
             return []
@@ -158,7 +128,9 @@ class GeminiRecommender(Recommender):
                 raise RecommenderError(f"Gemini request failed: {exc}") from exc
         raise RecommenderError("Gemini request failed after retries.")
 
-    def recommend_vibe(self, description: str, count: int, *, name_it: bool) -> VibeResult:
+    def recommend_vibe(
+        self, description: str, count: int, *, name_it: bool, seeds: list[Seed] | None = None
+    ) -> VibeResult:
         description = (description or "").strip()
         if not description or count <= 0:
             return VibeResult(suggestions=[])
@@ -166,10 +138,10 @@ class GeminiRecommender(Recommender):
         from google.genai import types
 
         ask = max(count, int(count * _VIBE_OVER_REQUEST))
-        prompt = self._build_vibe_prompt(description, ask, name_it)
+        prompt = vibe_prompt(description, ask, name_it=name_it, seeds=seeds)
         logger.debug(
-            "Gemini vibe: requesting %d suggestions (model=%s, name_it=%s) for %r",
-            ask, self._model, name_it, description,
+            "Gemini vibe: requesting %d suggestions (model=%s, name_it=%s, seeds=%d) for %r",
+            ask, self._model, name_it, len(seeds or ()), description,
         )
         logger.debug("Gemini vibe prompt:\n%s", prompt)
         config = types.GenerateContentConfig(

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -85,6 +85,9 @@ class VibeRequest(BaseModel):
     # ceiling — the LLM exhausts genuinely on-vibe picks well before 200 and starts to drift.
     num_songs: int = Field(40, ge=1, le=100)
     name_it: bool = True
+    # Optional source playlist to transform: when set, the vibe text is applied as a change
+    # to this playlist (regenerate it less hardcore, etc.) rather than built from scratch.
+    source_playlist: str | None = None
     # Optional per-request LLM override; when a valid LLM, it's also persisted to the
     # session so the vibe panel's picker remembers it. Absent ⇒ use the session default.
     engine: str | None = None

--- a/backend/routers/playlists.py
+++ b/backend/routers/playlists.py
@@ -128,6 +128,7 @@ def create_vibe(
         lambda: playlist_ops.create_vibe_playlist(
             client, recommender, body.description, body.num_songs,
             name_it=body.name_it, fill_recommender=fill_recommender,
+            source_playlist=body.source_playlist,
         )
     )
     return PlaylistMutationResponse(message=res.message, id=res.playlist_id, name=res.name, total_tracks=res.track_count)

--- a/frontend/js/playlistActions.js
+++ b/frontend/js/playlistActions.js
@@ -14,12 +14,16 @@ export function playlistActions() {
     playlistTab: 'library',     // 'library' (user's own) | 'app' (made by this app)
     sourceDropdownOpen: false,  // create-from-playlist source picker
     sourceSearch: '',
+    vibeSourceDropdownOpen: false,  // vibe mode's optional "transform this playlist" picker
+    vibeSourceSearch: '',
     actionLoading: false, // global mutex: one mutating action at a time
     busy: '',             // which action is running ('daily'|'weekly'|'delete'|'from'|'vibe')
     createMode: 'playlist',   // 'playlist' (seed from existing) | 'vibe' (free-text)
     createModeTouched: false, // true once the user picks a tab, so loadVibe's default doesn't override them
     createForm: { source: '', target: '', count: 60 },
-    vibeForm: { description: '', count: 40, nameIt: true },
+    // vibe `sourcePlaylist` is optional: empty ⇒ build from scratch; set ⇒ transform that
+    // playlist (the description becomes the change to apply).
+    vibeForm: { description: '', count: 40, nameIt: true, sourcePlaylist: '' },
 
     // ── Derived ──────────────────────────────────────────────────────────────
     // Plain methods, not getters: this object is SPREAD into the Alpine root
@@ -108,6 +112,8 @@ export function playlistActions() {
           description,
           num_songs: this.vibeForm.count,
           name_it: this.vibeForm.nameIt,
+          // Optional: when set, the build transforms this playlist instead of starting fresh.
+          source_playlist: this.vibeForm.sourcePlaylist || null,
           engine: this.vibe.active,       // remembered server-side for next time
           model: this.vibe.activeModel,   // ditto — the specific model within that engine
         }),
@@ -137,6 +143,27 @@ export function playlistActions() {
     },
     sourceOptions() {
       const q = this.sourceSearch.trim().toLowerCase();
+      if (!q) return this.playlists;
+      return this.playlists.filter((p) => p.name.toLowerCase().includes(q));
+    },
+
+    // ── Vibe-source selection (the optional "transform this playlist" picker) ──
+    // Separate from createForm's source so the two pickers don't share open/search state.
+    selectVibeSource(name) {
+      this.vibeForm.sourcePlaylist = name;
+      this.vibeSourceDropdownOpen = false;
+      this.vibeSourceSearch = '';
+    },
+    clearVibeSource() {
+      this.vibeForm.sourcePlaylist = '';
+      this.vibeSourceDropdownOpen = false;
+      this.vibeSourceSearch = '';
+    },
+    selectedVibeSourcePlaylist() {
+      return this.playlists.find((p) => p.name === this.vibeForm.sourcePlaylist) || null;
+    },
+    vibeSourceOptions() {
+      const q = this.vibeSourceSearch.trim().toLowerCase();
       if (!q) return this.playlists;
       return this.playlists.filter((p) => p.name.toLowerCase().includes(q));
     },

--- a/frontend/partials/create-from-playlist.html
+++ b/frontend/partials/create-from-playlist.html
@@ -96,11 +96,67 @@
 
   <!-- ── Mode: from a vibe (free text → LLM) ────────────────────────────── -->
   <div x-show="createMode === 'vibe'" x-cloak>
-    <p class="text-sm text-gray-400 mb-3">Describe a vibe — an LLM picks matching songs, each verified on Spotify.</p>
+    <p x-show="!vibeForm.sourcePlaylist" class="text-sm text-gray-400 mb-3">Describe a vibe — an LLM picks matching songs, each verified on Spotify.</p>
+    <p x-show="vibeForm.sourcePlaylist" x-cloak class="text-sm text-gray-400 mb-3">Describe how to change <span class="text-accent-400 font-medium" x-text="vibeForm.sourcePlaylist"></span> — the LLM rebuilds it with your tweak applied.</p>
 
     <textarea x-model="vibeForm.description" rows="2" maxlength="300"
-              placeholder="e.g. rainy sunday coffee-shop jazz · upbeat 2000s indie for a workout"
+              :placeholder="vibeForm.sourcePlaylist ? 'e.g. make it less hardcore · more upbeat · swap in some 90s tracks' : 'e.g. rainy sunday coffee-shop jazz · upbeat 2000s indie for a workout'"
               class="w-full bg-gray-950 border border-gray-700 rounded-lg px-3 py-2.5 text-sm placeholder:text-gray-600 focus:outline-none focus:ring-2 focus:ring-accent-500/60 focus:border-accent-500 resize-none"></textarea>
+
+    <!-- Optional "remix a playlist" picker — attach one and the vibe text becomes the
+         change to apply to it (regenerate, not edit). A secondary, compact control: it
+         shouldn't read as a co-equal input to the vibe textarea, just an optional add-on.
+         Mirrors the from-playlist source dropdown but with its own open/search state and a
+         clear (×) since it's optional. -->
+    <div class="mt-3">
+      <span class="text-xs text-gray-500">Remix a playlist <span class="text-gray-600">(optional)</span></span>
+      <div class="relative mt-1" @click.outside="vibeSourceDropdownOpen = false" @keydown.escape.window="vibeSourceDropdownOpen = false">
+        <button type="button" @click="vibeSourceDropdownOpen = !vibeSourceDropdownOpen"
+                class="w-full flex items-center gap-2 bg-gray-950/60 border rounded-md px-2.5 h-9 text-xs text-left transition-colors"
+                :class="vibeSourceDropdownOpen ? 'border-accent-500 ring-1 ring-accent-500/50' : 'border-gray-800 hover:border-gray-700'">
+          <img x-show="selectedVibeSourcePlaylist()" :src="selectedVibeSourcePlaylist()?.image_url" alt=""
+               class="w-5 h-5 rounded object-cover flex-shrink-0" />
+          <span class="flex-1 min-w-0 truncate" :class="selectedVibeSourcePlaylist() ? 'text-gray-200' : 'text-gray-500'"
+                x-text="selectedVibeSourcePlaylist()?.name || 'None — build from scratch'"></span>
+          <!-- Clear (×) when one is selected; chevron otherwise -->
+          <svg x-show="vibeForm.sourcePlaylist" @click.stop="clearVibeSource()" class="w-3.5 h-3.5 text-gray-500 hover:text-white flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+          <svg x-show="!vibeForm.sourcePlaylist" class="w-3.5 h-3.5 text-gray-500 flex-shrink-0 transition-transform" :class="vibeSourceDropdownOpen ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+        </button>
+
+        <div x-show="vibeSourceDropdownOpen" x-transition.opacity.duration.100ms x-cloak
+             class="absolute z-30 mt-1 w-full rounded-lg border border-gray-700 bg-gray-900 shadow-2xl overflow-hidden">
+          <div class="p-2 border-b border-gray-800">
+            <input x-model="vibeSourceSearch" type="text" placeholder="Search playlists…" @click.stop
+                   class="w-full bg-gray-950 border border-gray-700 rounded-md px-3 py-1.5 text-sm placeholder:text-gray-600 focus:outline-none focus:ring-1 focus:ring-accent-500" />
+          </div>
+          <div class="max-h-64 overflow-y-auto py-1">
+            <button type="button" @click="clearVibeSource()"
+                    class="w-full flex items-center gap-2.5 px-2.5 py-1.5 text-left hover:bg-gray-800 transition-colors text-sm text-gray-400">
+              <span class="w-8 h-8 rounded bg-gray-800 flex items-center justify-center flex-shrink-0">
+                <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+              </span>
+              <span class="flex-1">None — build from scratch</span>
+            </button>
+            <template x-for="p in vibeSourceOptions()" :key="p.name">
+              <button type="button" @click="selectVibeSource(p.name)"
+                      class="w-full flex items-center gap-2.5 px-2.5 py-1.5 text-left hover:bg-gray-800 transition-colors"
+                      :class="vibeForm.sourcePlaylist === p.name ? 'bg-accent-500/10' : ''">
+                <img :src="p.image_url" alt="" loading="lazy" class="w-8 h-8 rounded object-cover flex-shrink-0" />
+                <span class="flex-1 min-w-0">
+                  <span class="flex items-center gap-1.5">
+                    <span class="truncate text-sm text-white" x-text="p.name"></span>
+                    <span x-show="p.recently_played" class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-accent-400" title="Recently played"></span>
+                  </span>
+                  <span class="block text-xs text-gray-500" x-text="`${p.total_tracks} tracks`"></span>
+                </span>
+                <svg x-show="vibeForm.sourcePlaylist === p.name" class="w-4 h-4 text-accent-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
+              </button>
+            </template>
+            <div x-show="!vibeSourceOptions().length" class="px-3 py-4 text-center text-sm text-gray-600">No matches</div>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <!-- Engine picker (only when >1 LLM keyed) + AI-naming toggle, on one row. -->
     <div class="mt-4 flex flex-wrap items-center gap-x-6 gap-y-3">


### PR DESCRIPTION
Adds an optional playlist picker to **From a vibe**: attach a source playlist and the vibe text becomes the change to apply — "take this playlist, make it less hardcore". The LLM regenerates the playlist (regenerate, not edit) using a recency-weighted sample of the source as reference.

## Behavior
- **Seeds:** reuses `playlist_seeds()` — a recency-biased sample capped at 100, scaling down to playlists smaller than that.
- **Transform prompt:** new variant in shared `base.vibe_prompt()` — shift the named dimension, preserve everything unmentioned, same cohesion/anti-hallucination rules as pure vibe.
- **Last.fm hybrid fill** still layers on top of the LLM core.
- Backward-compatible: `source_playlist` is optional everywhere; empty ⇒ unchanged from-scratch vibe.

## Changes
- `base.py` — extracted shared `vibe_prompt()` (kills gemini/claude duplication) with pure + transform variants.
- `gemini.py` / `claude.py` — `recommend_vibe(..., seeds=None)`.
- `playlists.py` — `create_vibe_playlist(..., source_playlist=None)`, seed cap `_VIBE_SOURCE_SEED_MAX=100`.
- `schemas.py` / `routers/playlists.py` — optional `source_playlist` threaded through.
- Frontend — compact, low-emphasis "Remix a playlist (optional)" picker; copy/placeholder adapt when one is attached.